### PR TITLE
Fix incorrect gem version

### DIFF
--- a/lib/xero-ruby/version.rb
+++ b/lib/xero-ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 4.3.0
 =end
 
 module XeroRuby
-  VERSION = '0.4.1'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
After releasing v1.1.0 of this gem a commit was made that accidentally reverted the version file to v0.4.1 - this means that the our fork is reporting as 0.4.1 in the Cliniko Gemfile.lock.

Unfortunately 0.4.1 was yanked from Rubygems so `bundle update` is failing.

This change should resolve the Gemfile.lock and allow gem updating in Cliniko.